### PR TITLE
ER図を自動生成できるようにする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@
 
 /.env
 db/seed
+
+erd.*

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ end
 group :development do
   gem 'better_errors'
   gem 'binding_of_caller'
+  gem 'rails-erd'
   gem 'listen'
   gem 'spring'
   gem 'spring-commands-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,7 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    choice (0.2.0)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     crass (1.0.4)
@@ -204,6 +205,11 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
+    rails-erd (1.6.0)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
+      choice (~> 0.2.0)
+      ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
     rails-i18n (6.0.0)
@@ -244,6 +250,7 @@ GEM
     rspec-support (3.8.3)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
+    ruby-graphviz (1.2.4)
     rubyzip (1.3.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -338,6 +345,7 @@ DEPENDENCIES
   pry-rails
   puma
   rails (= 6.0.0)
+  rails-erd
   rails-i18n
   rspec-rails
   rspec_junit_formatter

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ $ bin/rails s
 ```
 
 ## ER図を生成
+先に`$ brew install graphviz`でGraphvizをインストールしておく。
 ```
 $ bin/rake erd
 

--- a/README.md
+++ b/README.md
@@ -35,3 +35,14 @@ $ bin/rspec
 ```
 $ bin/rails s
 ```
+
+## ER図を生成
+```
+$ bin/rake erd
+
+# UML形式で表示（エラーは無視していい）
+$ bin/rake erd notation=uml
+```
+デフォルトでは`erd.pdf`が生成されます。詳しくは[voormedia/rails-erd](https://github.com/voormedia/rails-erd)を参照。
+
+ちなみに、Rails6で動作するようにしているので、`bundle exec erd`では正しく生成されません。

--- a/lib/tasks/auto_generate_diagram.rake
+++ b/lib/tasks/auto_generate_diagram.rake
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+if Rails.env.development?
+  RailsERD.load_tasks
+
+  # TMP Fix for Rails 6.
+  Rake::Task["erd:load_models"].clear
+
+  namespace :erd do
+    task :load_models do
+      say "Loading application environment..."
+      Rake::Task[:environment].invoke
+
+      say "Loading code in search of Active Record models..."
+      Zeitwerk::Loader.eager_load_all
+    end
+  end
+end


### PR DESCRIPTION
`gem 'rails-erd'`を使うようにした。
https://github.com/voormedia/rails-erd

Rails6を使っていると、Zeitwerkの関係でうまくER図を生成できなかったので、`erd` Taskを書き換えることで対応した。
参考：https://github.com/voormedia/rails-erd/issues/322#issuecomment-517992445

なので、実行は`bundle exec erd`ではなく、
```
bin/rake erd
```
で行うようにする。