### PR TITLE
headless chromeに対応させる

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,8 +16,8 @@
 require 'capybara/rspec'
 
 RSpec.configure do |config|
-  config.before(:each, type: :system, js: true) do
-    driven_by :selenium_chrome_headless
+  config.before(:each, type: :system) do
+    driven_by :selenium, using: :headless_chrome
   end
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
### やったこと
- `js: true`でフィルタリングしていたため、config.beforeのブロックが無視されていたので、`js: true`を消した
- `driven_by :selenium_chrome_headless`だとscreen_sizeが小さくなって、リンクが表示されず（レスポンシブにしている関係で）、テストが落ちてしまうので、`driven_by :chrome, using: headless_chrome`を使うようにした

### 参考
- https://github.com/rails/rails/blob/cf43b71b64e21182c34e0907167e13fc917436bd/actionpack/lib/action_dispatch/system_test_case.rb#L68
- [rspec-rails 3.7の新機能！System Specを使ってみた - Qiita](https://qiita.com/jnchito/items/c7e6e7abf83598a6516d#%E3%83%98%E3%83%83%E3%83%89%E3%83%AC%E3%82%B9%E3%83%A2%E3%83%BC%E3%83%89%E3%81%AEchrome%E3%81%A7%E5%AE%9F%E8%A1%8C%E3%81%99%E3%82%8B)
- [How to set screen size for chrome headless system test in rails 5.1? - Stack Overflow](https://stackoverflow.com/questions/47182364/how-to-set-screen-size-for-chrome-headless-system-test-in-rails-5-1)