### PR TITLE
ランチ履歴を後日に登録できる機能

### DIFF
--- a/app/controllers/lunches_controller.rb
+++ b/app/controllers/lunches_controller.rb
@@ -9,10 +9,10 @@ class LunchesController < ApplicationController
   end
 
   def create
-    today = Date.today
+    date = params[:lunch][:date]
     members = Member.where(real_name: params[:lunch][:members])
-    quarter = Quarter.find_or_create_quarter(today)
-    @lunch = quarter.lunches.build(date: today, members: members, created_by: current_user)
+    quarter = Quarter.find_or_create_quarter(date)
+    @lunch = quarter.lunches.build(date: date, members: members, created_by: current_user)
     if @lunch.save
       flash[:success] = t('dictionary.message.create.complete', resource_name: @lunch.label_with_date_and_member_names)
       redirect_to lunches_url

--- a/app/views/lunches/new.html.slim
+++ b/app/views/lunches/new.html.slim
@@ -33,6 +33,6 @@ h3.my-3 ランチに行くメンバーを探す
           = f.text_field :member, name: 'lunch[members][]', readonly: true, class: 'form-control form-control-lg member-form'
         .form-group
           = f.label :date, '行った日'
-          = f.date_field :date, value: Date.today, class: 'form-control'
+          = f.date_field :date, value: Date.today, max: Date.today, class: 'form-control'
         .text-center
           = f.submit 'ランチに行く', id: 'submit-btn', class: 'btn btn-primary btn-lg'

--- a/app/views/lunches/new.html.slim
+++ b/app/views/lunches/new.html.slim
@@ -31,5 +31,8 @@ h3.my-3 ランチに行くメンバーを探す
           = f.text_field :member, name: 'lunch[members][]', readonly: true, class: 'form-control form-control-lg member-form'
         .form-group
           = f.text_field :member, name: 'lunch[members][]', readonly: true, class: 'form-control form-control-lg member-form'
+        .form-group
+          = f.label :date, '行った日'
+          = f.date_field :date, value: Date.today, class: 'form-control'
         .text-center
           = f.submit 'ランチに行く', id: 'submit-btn', class: 'btn btn-primary btn-lg'

--- a/spec/system/lunch_spec.rb
+++ b/spec/system/lunch_spec.rb
@@ -196,6 +196,18 @@ describe '3人組を探す機能' do
         expect(page).to have_content '3人のメンバーを入力してください'
       end
     end
+
+    describe '後日にランチに行った履歴を登録できる機能' do
+      it '昨日の日付で登録できること' do
+        find('.member-name', text: '鈴木一郎').click
+        find('.member-name', text: '鈴木二郎').click
+        find('.member-name', text: '鈴木三郎').click
+        fill_in '行った日', with: Date.yesterday
+        find('#submit-btn').click
+
+        expect(page).to have_content "#{Date.yesterday} 鈴木一郎,鈴木二郎,鈴木三郎の給付金利用履歴を登録しました"
+      end
+    end
   end
 
   describe 'ログインしているユーザーが自動でフォームの一人目に入力される機能' do


### PR DESCRIPTION
## 内容
ランチ登録フォームにランチに行った日を選択できるようにした。
それによって、行った当日に登録を忘れてしまった場合でも後日に登録できるようにした。
過去の日付を選択できればいいので、未来は選択できないようにしている。