### PR TITLE
ランチに行ったメンバーの名前をコピーするボタンを置く

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'rails', '6.0.0'
 
 gem 'bootsnap', require: false
 gem 'bootstrap'
+gem 'clipboard-rails'
 gem 'devise'
 gem 'devise-i18n'
 gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
       xpath (~> 3.2)
     childprocess (3.0.0)
     choice (0.2.0)
+    clipboard-rails (1.7.1)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     crass (1.0.5)
@@ -335,6 +336,7 @@ DEPENDENCIES
   bullet
   byebug
   capybara
+  clipboard-rails
   devise
   devise-i18n
   dotenv-rails

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,6 +15,7 @@
 //= require activestorage
 //= require turbolinks
 //= require_tree .
+//= require clipboard
 //= require select2
 //= require select2-full
 //= require popper

--- a/app/assets/javascripts/clipboard_button.js
+++ b/app/assets/javascripts/clipboard_button.js
@@ -1,0 +1,32 @@
+document.addEventListener('turbolinks:load', function(){
+  // Tooltip
+  $('.clipboard-btn').tooltip({
+    trigger: 'click',
+    placement: 'bottom'
+  });
+
+  function setTooltip(btn, message) {
+    $(btn).tooltip('show')
+      .attr('data-original-title', message)
+      .tooltip('show');
+  }
+
+  function hideTooltip(btn) {
+    setTimeout(function() {
+      $(btn).tooltip('hide');
+    }, 1000);
+  }
+
+  // Clipboard
+  var clipboard = new Clipboard('.clipboard-btn');
+
+  clipboard.on('success', function(e) {
+    setTooltip(e.trigger, 'Copied!');
+    hideTooltip(e.trigger);
+  });
+
+  clipboard.on('error', function(e) {
+    setTooltip(e.trigger, 'Failed!');
+    hideTooltip(e.trigger);
+  });
+});

--- a/app/views/lunches/index.html.slim
+++ b/app/views/lunches/index.html.slim
@@ -20,10 +20,11 @@ ul.nav.nav-tabs role="tablist"
           - quarter.lunches.each do |lunch|
             tr
               td = lunch.date
-              td = lunch.members.pluck(:real_name).join(',')
+              td
+                button.mx-3.btn.border-0.btn-outline-secondary.clipboard-btn data-clipboard-text="#{lunch.members.pluck(:real_name).join(',')}"
+                  = icon('far', 'copy')
+                .d-inline
+                  = lunch.members.pluck(:real_name).join(',')
               td
                 - if lunch.created_by == current_user
                   = link_to '削除', lunch, data: { confirm: t('dictionary.message.destroy.confirm', resource_name: lunch.label_with_date_and_member_names) }, method: :delete, class: 'btn btn-danger'
-
-
-


### PR DESCRIPTION
## 内容
申請のために、ランチに行ったメンバーの名前が必要なのですぐに入力できるように、ランチに行ったメンバーの名前をコピーするボタンを給付金利用履歴ページに置いた。

