### PR TITLE
日付が空欄で登録しようとするときエラー文を表示させる

### DIFF
--- a/app/controllers/lunches_controller.rb
+++ b/app/controllers/lunches_controller.rb
@@ -9,10 +9,10 @@ class LunchesController < ApplicationController
   end
 
   def create
-    @lunch_form = LunchForm.new(date: params[:lunch_form][:date])
+    @lunch_form = LunchForm.new(lunch_form_params)
 
     if @lunch_form.valid?
-      members = Member.where(real_name: params[:lunch_form][:members])
+      members = Member.where(real_name: @lunch_form.members)
       date = Date.parse(@lunch_form.date)
       quarter = Quarter.find_or_create_quarter(date)
       lunch = quarter.lunches.create!(date: date, members: members, created_by: current_user)
@@ -39,6 +39,10 @@ class LunchesController < ApplicationController
   end
 
   private
+
+  def lunch_form_params
+    params.require(:lunch_form).permit(:date, members: [])
+  end
 
   def set_variables_for_new_lunch_view
     @members = Member.includes(:projects).where(retired: false).order(:created_at)

--- a/app/controllers/lunches_controller.rb
+++ b/app/controllers/lunches_controller.rb
@@ -5,16 +5,18 @@ class LunchesController < ApplicationController
 
   def new
     set_variables_for_new_lunch_view
-    @lunch = Lunch.new
+    @lunch_form = LunchForm.new
   end
 
   def create
-    date = Date.parse(params[:lunch][:date])
-    members = Member.where(real_name: params[:lunch][:members])
-    quarter = Quarter.find_or_create_quarter(date)
-    @lunch = quarter.lunches.build(date: date, members: members, created_by: current_user)
-    if @lunch.save
-      flash[:success] = t('dictionary.message.create.complete', resource_name: @lunch.label_with_date_and_member_names)
+    @lunch_form = LunchForm.new(date: params[:lunch_form][:date])
+
+    if @lunch_form.valid?
+      members = Member.where(real_name: params[:lunch_form][:members])
+      date = Date.parse(@lunch_form.date)
+      quarter = Quarter.find_or_create_quarter(date)
+      lunch = quarter.lunches.create!(date: date, members: members, created_by: current_user)
+      flash[:success] = t('dictionary.message.create.complete', resource_name: lunch.label_with_date_and_member_names)
       redirect_to lunches_url
     else
       set_variables_for_new_lunch_view

--- a/app/controllers/lunches_controller.rb
+++ b/app/controllers/lunches_controller.rb
@@ -13,7 +13,7 @@ class LunchesController < ApplicationController
 
     if @lunch_form.valid?
       members = Member.where(real_name: @lunch_form.members)
-      date = Date.parse(@lunch_form.date)
+      date = @lunch_form.date.to_date
       quarter = Quarter.find_or_create_quarter(date)
       lunch = quarter.lunches.create!(date: date, members: members, created_by: current_user)
       flash[:success] = t('dictionary.message.create.complete', resource_name: lunch.label_with_date_and_member_names)

--- a/app/models/lunch.rb
+++ b/app/models/lunch.rb
@@ -2,6 +2,8 @@ class Lunch < ApplicationRecord
   belongs_to :created_by,  foreign_key: :user_id, class_name: 'User'
   belongs_to :quarter
   has_and_belongs_to_many :members
+
+  validates :date, presence: true
   validate :must_have_benefits_available_count_members
   validate :must_go_to_lunch_with_members_who_did_not_go_together_during_same_quarter
 

--- a/app/models/lunch.rb
+++ b/app/models/lunch.rb
@@ -3,23 +3,13 @@ class Lunch < ApplicationRecord
   belongs_to :quarter
   has_and_belongs_to_many :members
 
-  validates :date, presence: true
-  validate :must_have_benefits_available_count_members
   validate :must_go_to_lunch_with_members_who_did_not_go_together_during_same_quarter
-
-  BENEFITS_AVAILABLE_MEMBERS_COUNT = 3
 
   def label_with_date_and_member_names
     "#{date} #{members.pluck(:real_name).join(',')}の給付金利用履歴"
   end
 
   private
-
-  def must_have_benefits_available_count_members
-    return if members.size == BENEFITS_AVAILABLE_MEMBERS_COUNT
-
-    errors.add(:members, "#{BENEFITS_AVAILABLE_MEMBERS_COUNT}人のメンバーを入力してください")
-  end
 
   # 同じクォーター内で同じメンバーの組み合わせでランチに行ってないことを検証
   def must_go_to_lunch_with_members_who_did_not_go_together_during_same_quarter

--- a/app/models/lunch_form.rb
+++ b/app/models/lunch_form.rb
@@ -13,13 +13,13 @@ class LunchForm
   def must_have_benefits_available_count_members
     return if members.count(&:present?) == BENEFITS_AVAILABLE_MEMBERS_COUNT
 
-    errors.add(:members_count, "#{BENEFITS_AVAILABLE_MEMBERS_COUNT}人のメンバーを入力してください")
+    errors.add(:members, "#{BENEFITS_AVAILABLE_MEMBERS_COUNT}人のメンバーを入力してください")
   end
 
   # 実在する member が指定されていること
   def members_should_exist
     return if Member.where(real_name: members).count == members.count
 
-    errors.add(:members_exist, '存在する名前を入力してください')
+    errors.add(:members, '存在する名前を入力してください')
   end
 end

--- a/app/models/lunch_form.rb
+++ b/app/models/lunch_form.rb
@@ -1,7 +1,23 @@
 class LunchForm
   include ActiveModel::Model
 
-  attr_accessor :date
+  attr_accessor :date, :members
 
   validates :date, presence: true
+  validate :must_have_benefits_available_count_members
+  validate :members_should_exist
+
+  BENEFITS_AVAILABLE_MEMBERS_COUNT = 3
+
+  # 規定人数が満たされていること
+  def must_have_benefits_available_count_members
+    return if members.count(&:present?) == BENEFITS_AVAILABLE_MEMBERS_COUNT
+
+    errors.add(:members, "#{BENEFITS_AVAILABLE_MEMBERS_COUNT}人のメンバーを入力してください")
+  end
+
+  # 実在する member が指定されていること
+  def members_should_exist
+    true
+  end
 end

--- a/app/models/lunch_form.rb
+++ b/app/models/lunch_form.rb
@@ -13,11 +13,13 @@ class LunchForm
   def must_have_benefits_available_count_members
     return if members.count(&:present?) == BENEFITS_AVAILABLE_MEMBERS_COUNT
 
-    errors.add(:members, "#{BENEFITS_AVAILABLE_MEMBERS_COUNT}人のメンバーを入力してください")
+    errors.add(:members_count, "#{BENEFITS_AVAILABLE_MEMBERS_COUNT}人のメンバーを入力してください")
   end
 
   # 実在する member が指定されていること
   def members_should_exist
-    true
+    return if Member.where(real_name: members).count == members.count
+
+    errors.add(:members_exist, '存在する名前を入力してください')
   end
 end

--- a/app/models/lunch_form.rb
+++ b/app/models/lunch_form.rb
@@ -4,10 +4,16 @@ class LunchForm
   attr_accessor :date, :members
 
   validates :date, presence: {message: '日付を入力してください'}
+  validate :date_must_be_in_the_past, if: -> { date.present? }
   validate :must_have_benefits_available_count_members
   validate :members_should_exist
 
   BENEFITS_AVAILABLE_MEMBERS_COUNT = 3
+
+  def date_must_be_in_the_past
+    return if date.to_date <= Date.current
+    errors.add(:date, "今日までの日付を入力してください")
+  end
 
   # 規定人数が満たされていること
   def must_have_benefits_available_count_members

--- a/app/models/lunch_form.rb
+++ b/app/models/lunch_form.rb
@@ -1,0 +1,7 @@
+class LunchForm
+  include ActiveModel::Model
+
+  attr_accessor :date
+
+  validates :date, presence: true
+end

--- a/app/models/lunch_form.rb
+++ b/app/models/lunch_form.rb
@@ -3,7 +3,7 @@ class LunchForm
 
   attr_accessor :date, :members
 
-  validates :date, presence: true
+  validates :date, presence: {message: '日付を入力してください'}
   validate :must_have_benefits_available_count_members
   validate :members_should_exist
 

--- a/app/views/lunches/new.html.slim
+++ b/app/views/lunches/new.html.slim
@@ -23,8 +23,8 @@ h3.my-3 ランチに行くメンバーを探す
         - if @lunch_form.errors.any?
           .text-danger
             ul
-              - @lunch_form.errors.messages.values.flatten.each do |message|
-                li = message
+              - @lunch_form.errors.messages.each do |attr, messages|
+                li = messages.first
         .form-group
           = f.text_field :member, name: 'lunch_form[members][]', readonly: true, class: 'form-control form-control-lg member-form'
         .form-group

--- a/app/views/lunches/new.html.slim
+++ b/app/views/lunches/new.html.slim
@@ -19,18 +19,18 @@ h3.my-3 ランチに行くメンバーを探す
                 td.unselectable-reason
 
     .col-4
-      = form_with model: @lunch, local: true, class: 'lunch-form' do |f|
-        - if @lunch.errors.any?
+      = form_with model: @lunch_form, url: lunches_path, local: true, class: 'lunch-form' do |f|
+        - if @lunch_form.errors.any?
           .text-danger
             ul
-              - @lunch.errors.messages.values.flatten.each do |message|
+              - @lunch_form.errors.messages.values.flatten.each do |message|
                 li = message
         .form-group
-          = f.text_field :member, name: 'lunch[members][]', readonly: true, class: 'form-control form-control-lg member-form'
+          = f.text_field :member, name: 'lunch_form[members][]', readonly: true, class: 'form-control form-control-lg member-form'
         .form-group
-          = f.text_field :member, name: 'lunch[members][]', readonly: true, class: 'form-control form-control-lg member-form'
+          = f.text_field :member, name: 'lunch_form[members][]', readonly: true, class: 'form-control form-control-lg member-form'
         .form-group
-          = f.text_field :member, name: 'lunch[members][]', readonly: true, class: 'form-control form-control-lg member-form'
+          = f.text_field :member, name: 'lunch_form[members][]', readonly: true, class: 'form-control form-control-lg member-form'
         .form-group
           = f.label :date, '行った日'
           = f.date_field :date, value: Date.current, max: Date.current, class: 'form-control'

--- a/spec/model/lunch_form_spec.rb
+++ b/spec/model/lunch_form_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe LunchForm do
       end
     end
 
-    context '存在しない３人がmembersに指定された場合' do
+    context '人数は満たしているが、存在しないmembersが指定された場合' do
       let(:members) { ['鈴木存在しない一郎', '鈴木二郎', '鈴木三郎'] }
 
       it { is_expected.not_to be_valid }

--- a/spec/model/lunch_form_spec.rb
+++ b/spec/model/lunch_form_spec.rb
@@ -1,6 +1,35 @@
 require 'rails_helper'
 
 RSpec.describe LunchForm do
+  describe 'dateのバリデーション' do
+    let(:lunch_form_params) { {date: date , members: ['鈴木一郎', '鈴木二郎', '鈴木三郎']} }
+
+    before do
+      create(:member, real_name: '鈴木一郎')
+      create(:member, real_name: '鈴木二郎')
+      create(:member, real_name: '鈴木三郎')
+    end
+
+    subject { described_class.new(lunch_form_params) }
+
+    context '日付が今日の場合' do
+      let(:date){ Date.current.to_s }
+
+      it { is_expected.to be_valid }
+    end
+
+    context '日付が明日の場合' do
+      let(:date){ Date.tomorrow.to_s }
+
+      it { is_expected.not_to be_valid }
+
+      it '「今日までの日付を入力してください」のエラーメッセージになること' do
+        subject.valid?
+        expect(subject.errors.messages).to eq({date: ['今日までの日付を入力してください']})
+      end
+    end
+  end
+
   describe 'membersのバリデーション' do
     let(:lunch_form_params) { {date: '2019-11-21', members: members} }
 

--- a/spec/model/lunch_form_spec.rb
+++ b/spec/model/lunch_form_spec.rb
@@ -2,67 +2,42 @@ require 'rails_helper'
 
 RSpec.describe LunchForm do
   describe 'membersのバリデーション' do
+    let(:lunch_form_params) { {date: '2019-11-21', members: members} }
+
+    before do
+      create(:member, real_name: '鈴木一郎')
+      create(:member, real_name: '鈴木二郎')
+      create(:member, real_name: '鈴木三郎')
+    end
+
+    subject { described_class.new(lunch_form_params) }
+
     context '存在する３人がmembersに指定された場合' do
-      it '有効であること' do
-      end
+      let(:members) { ['鈴木一郎', '鈴木二郎', '鈴木三郎'] }
+
+      it { is_expected.to be_valid }
     end
 
     context '存在する2人がmembersに指定された場合' do
-      it '有効でないこと' do
-      end
+      let(:members) { ['鈴木一郎', '鈴木二郎'] }
+
+      it { is_expected.not_to be_valid }
 
       it '「3人のメンバーを入力してください」のエラーメッセージになること' do
+        subject.valid?
+        expect(subject.errors.messages[:members_count]).to eq ['3人のメンバーを入力してください']
       end
     end
 
     context '存在しない３人がmembersに指定された場合' do
-      it '有効でないこと' do
-      end
+      let(:members) { ['鈴木存在しない一郎', '鈴木二郎', '鈴木三郎'] }
+
+      it { is_expected.not_to be_valid }
 
       it '「存在する名前を入力してください」のエラーメッセージになること' do
+        subject.valid?
+        expect(subject.errors.messages[:members_exist]).to eq ['存在する名前を入力してください']
       end
     end
   end
-
-  # describe '#must_have_benefits_available_count_members' do
-  #   let(:lunch_form_params) { {date: '2019-11-21', members: members} }
-
-  #   subject { described_class.new(lunch_form_params) }
-
-  #   context '3 人指定されているとき' do
-  #     let(:members) { ['111', 'bbb','ccc'] }
-
-  #     it { is_expected.to be_valid }
-  #   end
-
-  #   context '2 人指定されているとき' do
-  #     let(:members) { ['111', 'bbb'] }
-
-  #     it { is_expected.not_to be_valid }
-  #   end
-  # end
-
-  # describe '#members_should_exist' do
-  #   let(:lunch_form_params) { {date: '2019-11-21', members: members} }
-
-  #   subject { described_class.new(lunch_form_params) }
-
-  #   before do
-  #     create(:member, real_name: '鈴木一郎')
-  #     create(:member, real_name: '鈴木二郎')
-  #     create(:member, real_name: '鈴木三郎')
-  #   end
-
-  #   context '存在するメンバーの名前が渡されるとき' do
-  #     let(:members) { ['鈴木一郎', '鈴木二郎', '鈴木三郎'] }
-
-  #     it { is_expected.to be_valid }
-  #   end
-
-  #   context '存在しないメンバーの名前が渡されるとき' do
-  #     let(:members) { ['鈴木存在しない一郎', '鈴木二郎', '鈴木三郎'] }
-
-  #     it { is_expected.not_to be_valid }
-  #   end
-  # end
 end

--- a/spec/model/lunch_form_spec.rb
+++ b/spec/model/lunch_form_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe LunchForm do
 
       it '「3人のメンバーを入力してください」のエラーメッセージになること' do
         subject.valid?
-        expect(subject.errors.messages).to eq({members_count: ['3人のメンバーを入力してください']})
+        expect(subject.errors.messages).to eq({members: ['3人のメンバーを入力してください']})
       end
     end
 
@@ -36,7 +36,7 @@ RSpec.describe LunchForm do
 
       it '「存在する名前を入力してください」のエラーメッセージになること' do
         subject.valid?
-        expect(subject.errors.messages).to eq({members_exist: ['存在する名前を入力してください']})
+        expect(subject.errors.messages).to eq({members: ['存在する名前を入力してください']})
       end
     end
 
@@ -47,7 +47,7 @@ RSpec.describe LunchForm do
 
       it 'それぞれのエラーメッセージが返されること' do
         subject.valid?
-        expect(subject.errors.messages).to eq({members_count: ['3人のメンバーを入力してください'], members_exist: ['存在する名前を入力してください']})
+        expect(subject.errors.messages).to eq({members: ['3人のメンバーを入力してください', '存在する名前を入力してください']})
       end
     end
   end

--- a/spec/model/lunch_form_spec.rb
+++ b/spec/model/lunch_form_spec.rb
@@ -1,43 +1,68 @@
 require 'rails_helper'
-  describe '#must_have_benefits_available_count_members' do
-    let(:lunch_form_params) { {date: '2019-11-21', members: members} }
 
-    subject { described_class.new(lunch_form_params) }
-
-    context '3 人指定されているとき' do
-      let(:members) { ['111', 'bbb','ccc'] }
-
-      it { is_expected.to be_valid }
+RSpec.describe LunchForm do
+  describe 'membersのバリデーション' do
+    context '存在する３人がmembersに指定された場合' do
+      it '有効であること' do
+      end
     end
 
-    context '2 人指定されているとき' do
-      let(:members) { ['111', 'bbb'] }
+    context '存在する2人がmembersに指定された場合' do
+      it '有効でないこと' do
+      end
 
-      it { is_expected.not_to be_valid }
-    end
-  end
-
-  describe '#members_should_exist' do
-    let(:lunch_form_params) { {date: '2019-11-21', members: members} }
-
-    subject { described_class.new(lunch_form_params) }
-
-    before do
-      create(:member, real_name: '鈴木一郎')
-      create(:member, real_name: '鈴木二郎')
-      create(:member, real_name: '鈴木三郎')
+      it '「3人のメンバーを入力してください」のエラーメッセージになること' do
+      end
     end
 
-    context '存在するメンバーの名前が渡されるとき' do
-      let(:members) { ['鈴木一郎', '鈴木二郎', '鈴木三郎'] }
+    context '存在しない３人がmembersに指定された場合' do
+      it '有効でないこと' do
+      end
 
-      it { is_expected.to be_valid }
-    end
-
-    context '存在しないメンバーの名前が渡されるとき' do
-      let(:members) { ['鈴木存在しない一郎', '鈴木二郎', '鈴木三郎'] }
-
-      it { is_expected.not_to be_valid }
+      it '「存在する名前を入力してください」のエラーメッセージになること' do
+      end
     end
   end
+
+  # describe '#must_have_benefits_available_count_members' do
+  #   let(:lunch_form_params) { {date: '2019-11-21', members: members} }
+
+  #   subject { described_class.new(lunch_form_params) }
+
+  #   context '3 人指定されているとき' do
+  #     let(:members) { ['111', 'bbb','ccc'] }
+
+  #     it { is_expected.to be_valid }
+  #   end
+
+  #   context '2 人指定されているとき' do
+  #     let(:members) { ['111', 'bbb'] }
+
+  #     it { is_expected.not_to be_valid }
+  #   end
+  # end
+
+  # describe '#members_should_exist' do
+  #   let(:lunch_form_params) { {date: '2019-11-21', members: members} }
+
+  #   subject { described_class.new(lunch_form_params) }
+
+  #   before do
+  #     create(:member, real_name: '鈴木一郎')
+  #     create(:member, real_name: '鈴木二郎')
+  #     create(:member, real_name: '鈴木三郎')
+  #   end
+
+  #   context '存在するメンバーの名前が渡されるとき' do
+  #     let(:members) { ['鈴木一郎', '鈴木二郎', '鈴木三郎'] }
+
+  #     it { is_expected.to be_valid }
+  #   end
+
+  #   context '存在しないメンバーの名前が渡されるとき' do
+  #     let(:members) { ['鈴木存在しない一郎', '鈴木二郎', '鈴木三郎'] }
+
+  #     it { is_expected.not_to be_valid }
+  #   end
+  # end
 end

--- a/spec/model/lunch_form_spec.rb
+++ b/spec/model/lunch_form_spec.rb
@@ -39,5 +39,16 @@ RSpec.describe LunchForm do
         expect(subject.errors.messages[:members_exist]).to eq ['存在する名前を入力してください']
       end
     end
+
+    context '人数を満たしておらず、存在しないmembersが指定された場合' do
+      let(:members) { ['鈴木存在しない一郎', '鈴木二郎'] }
+
+      it { is_expected.not_to be_valid }
+
+      it '「存在する名前を入力してください」のエラーメッセージになること' do
+        subject.valid?
+        expect(subject.errors.messages).to eq({members_count: ['3人のメンバーを入力してください'], members_exist: ['存在する名前を入力してください']})
+      end
+    end
   end
 end

--- a/spec/model/lunch_form_spec.rb
+++ b/spec/model/lunch_form_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe LunchForm do
 
       it { is_expected.not_to be_valid }
 
-      it '「存在する名前を入力してください」のエラーメッセージになること' do
+      it 'それぞれのエラーメッセージが返されること' do
         subject.valid?
         expect(subject.errors.messages).to eq({members_count: ['3人のメンバーを入力してください'], members_exist: ['存在する名前を入力してください']})
       end

--- a/spec/model/lunch_form_spec.rb
+++ b/spec/model/lunch_form_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe LunchForm do
 
       it '「3人のメンバーを入力してください」のエラーメッセージになること' do
         subject.valid?
-        expect(subject.errors.messages[:members_count]).to eq ['3人のメンバーを入力してください']
+        expect(subject.errors.messages).to eq({members_count: ['3人のメンバーを入力してください']})
       end
     end
 
@@ -36,7 +36,7 @@ RSpec.describe LunchForm do
 
       it '「存在する名前を入力してください」のエラーメッセージになること' do
         subject.valid?
-        expect(subject.errors.messages[:members_exist]).to eq ['存在する名前を入力してください']
+        expect(subject.errors.messages).to eq({members_exist: ['存在する名前を入力してください']})
       end
     end
 

--- a/spec/model/lunch_form_spec.rb
+++ b/spec/model/lunch_form_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe LunchForm do
+  describe '#must_have_benefits_available_count_members' do
+    let(:lunch_form_params) { {date: '2019-11-21', members: members} }
+
+    subject { described_class.new(lunch_form_params) }
+
+    context '3 人指定されているとき' do
+      let(:members) { ['111', 'bbb','ccc'] }
+
+      it { is_expected.to be_valid }
+    end
+
+    context '2 人指定されているとき' do
+      let(:members) { ['111', 'bbb'] }
+
+      it { is_expected.not_to be_valid }
+    end
+  end
+end

--- a/spec/model/lunch_form_spec.rb
+++ b/spec/model/lunch_form_spec.rb
@@ -1,6 +1,4 @@
 require 'rails_helper'
-
-RSpec.describe LunchForm do
   describe '#must_have_benefits_available_count_members' do
     let(:lunch_form_params) { {date: '2019-11-21', members: members} }
 
@@ -14,6 +12,30 @@ RSpec.describe LunchForm do
 
     context '2 人指定されているとき' do
       let(:members) { ['111', 'bbb'] }
+
+      it { is_expected.not_to be_valid }
+    end
+  end
+
+  describe '#members_should_exist' do
+    let(:lunch_form_params) { {date: '2019-11-21', members: members} }
+
+    subject { described_class.new(lunch_form_params) }
+
+    before do
+      create(:member, real_name: '鈴木一郎')
+      create(:member, real_name: '鈴木二郎')
+      create(:member, real_name: '鈴木三郎')
+    end
+
+    context '存在するメンバーの名前が渡されるとき' do
+      let(:members) { ['鈴木一郎', '鈴木二郎', '鈴木三郎'] }
+
+      it { is_expected.to be_valid }
+    end
+
+    context '存在しないメンバーの名前が渡されるとき' do
+      let(:members) { ['鈴木存在しない一郎', '鈴木二郎', '鈴木三郎'] }
 
       it { is_expected.not_to be_valid }
     end

--- a/spec/model/lunch_spec.rb
+++ b/spec/model/lunch_spec.rb
@@ -1,13 +1,6 @@
 require 'rails_helper'
 
 describe Lunch do
-  it '3人のメンバーが選ばれていないと有効ではないこと' do
-    member1 = create(:member, real_name: '鈴木一郎')
-    member2 = create(:member, real_name: '鈴木二郎')
-    lunch = build(:lunch, members: [member1, member2])
-    expect(lunch).to_not be_valid
-  end
-
   it '同じクォーターの中で同じ組み合わせがあると、有効ではないこと' do
     members = [
       create(:member, real_name: '鈴木一郎'),

--- a/spec/system/lunch_spec.rb
+++ b/spec/system/lunch_spec.rb
@@ -196,25 +196,39 @@ describe '3人組を探す機能' do
       end
     end
 
-    describe '後日にランチに行った履歴を登録できる機能' do
-      it '昨日の日付で登録できること' do
-        find('.member-name', text: '鈴木一郎').click
-        find('.member-name', text: '鈴木二郎').click
-        find('.member-name', text: '鈴木三郎').click
-        fill_in '行った日', with: Date.yesterday
-        find('#submit-btn').click
+    describe '日付を指定してランチに行った履歴を登録できる機能' do
+      context '日付が入力された状態で送信する場合' do
+        it '昨日の日付で登録できること' do
+          find('.member-name', text: '鈴木一郎').click
+          find('.member-name', text: '鈴木二郎').click
+          find('.member-name', text: '鈴木三郎').click
+          fill_in '行った日', with: Date.yesterday
+          find('#submit-btn').click
 
-        expect(page).to have_content "#{Date.yesterday} 鈴木一郎,鈴木二郎,鈴木三郎の給付金利用履歴を登録しました"
+          expect(page).to have_content "#{Date.yesterday} 鈴木一郎,鈴木二郎,鈴木三郎の給付金利用履歴を登録しました"
+        end
+
+        it '前の期の日付で登録できること' do
+          find('.member-name', text: '鈴木一郎').click
+          find('.member-name', text: '鈴木二郎').click
+          find('.member-name', text: '鈴木三郎').click
+          fill_in '行った日', with: Date.current.prev_month(3)
+          find('#submit-btn').click
+
+          expect(page).to have_content "#{ Date.current.prev_month(3)} 鈴木一郎,鈴木二郎,鈴木三郎の給付金利用履歴を登録しました"
+        end
       end
 
-      it '前の期の日付で登録できること' do
-        find('.member-name', text: '鈴木一郎').click
-        find('.member-name', text: '鈴木二郎').click
-        find('.member-name', text: '鈴木三郎').click
-        fill_in '行った日', with: Date.current.prev_month(3)
-        find('#submit-btn').click
+      context '日付を空にして送信する場合' do
+        it 'エラーが表示されること' do
+          find('.member-name', text: '鈴木一郎').click
+          find('.member-name', text: '鈴木二郎').click
+          find('.member-name', text: '鈴木三郎').click
+          fill_in '行った日', with: nil
+          find('#submit-btn').click
 
-        expect(page).to have_content "#{ Date.current.prev_month(3)} 鈴木一郎,鈴木二郎,鈴木三郎の給付金利用履歴を登録しました"
+          expect(true).to be true
+        end
       end
     end
   end

--- a/spec/system/lunch_spec.rb
+++ b/spec/system/lunch_spec.rb
@@ -175,60 +175,45 @@ describe '3人組を探す機能' do
   end
 
   describe 'ランチに行ったことの登録機能' do
-    context '3人を選ぶ場合' do
-      it 'ランチに行ったことが登録できること' do
-        find('.member-name', text: '鈴木一郎').click
-        find('.member-name', text: '鈴木二郎').click
-        find('.member-name', text: '鈴木三郎').click
-        find('#submit-btn').click
+    context '正しい入力をする場合' do
+      context '今日の日付で登録する場合' do
+        let(:date) { Date.current }
 
-        expect(page).to have_content '鈴木一郎,鈴木二郎,鈴木三郎の給付金利用履歴を登録しました'
-      end
-    end
-
-    context '3人未満を選ぶ場合' do
-      it 'ランチに行ったことが登録できないこと' do
-        find('.member-name', text: '鈴木一郎').click
-        find('.member-name', text: '鈴木二郎').click
-        find('#submit-btn').click
-
-        expect(page).to have_content '3人のメンバーを入力してください'
-      end
-    end
-
-    describe '日付を指定してランチに行った履歴を登録できる機能' do
-      context '日付が入力された状態で送信する場合' do
-        it '昨日の日付で登録できること' do
+        it '正しく登録されたことのメッセージが表示されること' do
           find('.member-name', text: '鈴木一郎').click
           find('.member-name', text: '鈴木二郎').click
           find('.member-name', text: '鈴木三郎').click
-          fill_in '行った日', with: Date.yesterday
+          fill_in '行った日', with: date
           find('#submit-btn').click
 
-          expect(page).to have_content "#{Date.yesterday} 鈴木一郎,鈴木二郎,鈴木三郎の給付金利用履歴を登録しました"
+          expect(page).to have_content '鈴木一郎,鈴木二郎,鈴木三郎の給付金利用履歴を登録しました'
         end
+      end
 
-        it '前の期の日付で登録できること' do
+      context '前の期の日付で登録する場合' do
+        let(:date) { Date.current.prev_month(3) }
+
+        it '正しく登録されたことのメッセージが表示されること' do
           find('.member-name', text: '鈴木一郎').click
           find('.member-name', text: '鈴木二郎').click
           find('.member-name', text: '鈴木三郎').click
-          fill_in '行った日', with: Date.current.prev_month(3)
+          fill_in '行った日', with: date
           find('#submit-btn').click
 
           expect(page).to have_content "#{ Date.current.prev_month(3)} 鈴木一郎,鈴木二郎,鈴木三郎の給付金利用履歴を登録しました"
         end
       end
+    end
 
-      context '日付を空にして送信する場合' do
-        it 'エラーが表示されること' do
-          find('.member-name', text: '鈴木一郎').click
-          find('.member-name', text: '鈴木二郎').click
-          find('.member-name', text: '鈴木三郎').click
-          fill_in '行った日', with: nil
-          find('#submit-btn').click
+    context '不正な入力をする場合' do
+      it 'エラーメッセージが表示されること' do
+        find('.member-name', text: '鈴木一郎').click
+        find('.member-name', text: '鈴木二郎').click
+        fill_in '行った日', with: nil
+        find('#submit-btn').click
 
-          expect(true).to be true
-        end
+        expect(page).to have_content '3人のメンバーを入力してください'
+        expect(page).to have_content '日付を入力してください'
       end
     end
   end


### PR DESCRIPTION
## 内容
日付が空欄でランチを登録しようとすると例外が発生していた。空で登録しようとしても、「日付を入力してください」を表示させるようにした。
