### PR TITLE
プロジェクトを削除するとき、所属するメンバーがわかるようにする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby '2.6.5'
 
 gem 'rails', '6.0.0'
 
+gem 'active_decorator'
 gem 'bootsnap', require: false
 gem 'bootstrap'
 gem 'clipboard-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_decorator (1.3.2)
+      activesupport
     activejob (6.0.0)
       activesupport (= 6.0.0)
       globalid (>= 0.3.6)
@@ -363,6 +365,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_decorator
   better_errors
   binding_of_caller
   bootsnap

--- a/app/decorators/project_decorator.rb
+++ b/app/decorators/project_decorator.rb
@@ -1,0 +1,9 @@
+module ProjectDecorator
+  def delete_confirm
+    if members.present?
+      "#{name}には#{members.pluck(:real_name).join('、')}が所属しています。#{name}を削除しますか？"
+    else
+      "#{name}を削除しますか？"
+    end
+  end
+end

--- a/app/views/projects/_form.html.slim
+++ b/app/views/projects/_form.html.slim
@@ -11,5 +11,4 @@
   = f.submit id: 'submit-btn', class: 'btn btn-primary'
 
 - if @project.persisted?
-  hr
-  = link_to '削除する', @project, data: { confirm: t('dictionary.message.destroy.confirm', resource_name: @project.name) }, method: :delete, class: 'btn btn-outline-danger'
+  = link_to '削除する', @project, data: { confirm: "#{@project.name}には#{@project.members.pluck(:real_name).join('、')}が所属しています。#{@project.name}を削除しますか？" }, method: :delete, class: 'btn btn-outline-danger'

--- a/app/views/projects/_form.html.slim
+++ b/app/views/projects/_form.html.slim
@@ -11,4 +11,4 @@
   = f.submit id: 'submit-btn', class: 'btn btn-primary'
 
 - if @project.persisted?
-  = link_to '削除する', @project, data: { confirm: "#{@project.name}には#{@project.members.pluck(:real_name).join('、')}が所属しています。#{@project.name}を削除しますか？" }, method: :delete, class: 'btn btn-outline-danger'
+  = link_to '削除する', @project, data: { confirm: @project.delete_confirm }, method: :delete, class: 'btn btn-outline-danger'

--- a/spec/decorators/project_decorator_spec.rb
+++ b/spec/decorators/project_decorator_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe ProjectDecorator do
+  describe '#delete_confirm' do
+    subject { project.delete_confirm }
+
+    let(:project) { Project.new(name: 'eiwakun').extend described_class }
+
+    context '所属メンバーがいる場合' do
+      before do
+        create(:member, real_name: '永和太郎', projects: [project])
+      end
+
+      it { is_expected.to eq 'eiwakunには永和太郎が所属しています。eiwakunを削除しますか？' }
+    end
+
+    context '所属メンバーがいない場合' do
+      it { is_expected.to eq 'eiwakunを削除しますか？' }
+    end
+  end
+end


### PR DESCRIPTION
## 内容
プロジェクトを削除するとき、そのプロジェクトにどのメンバーが所属しているかを警告するようにした。
