### PR TITLE
circle-ciのpostgresコンテナのエラーを修正した

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,8 @@ jobs:
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
       - image: circleci/postgres:9.4
+        environment:
+          POSTGRES_HOST_AUTH_METHOD: trust
 
     working_directory: ~/lunchpack
 


### PR DESCRIPTION
## 発生したエラー
```
Error: Database is uninitialized and superuser password is not specified.
       You must specify POSTGRES_PASSWORD for the superuser. Use
       "-e POSTGRES_PASSWORD=password" to set it in "docker run".

       You may also use POSTGRES_HOST_AUTH_METHOD=trust to allow all connections
       without a password. This is *not* recommended. See PostgreSQL
       documentation about "trust":
       https://www.postgresql.org/docs/current/auth-trust.html

Exited with code 1
CircleCI received exit code 1
```

## やったこと
`POSTGRES_PASSWORD`を設定しないといけないのかわからなかったので、
`POSTGRES_HOST_AUTH_METHOD: trust`で簡単に設定した。

参考のissue
https://github.com/docker-library/postgres/issues/681
